### PR TITLE
Switch to golang.org/x/term

### DIFF
--- a/dev/client/main.go
+++ b/dev/client/main.go
@@ -11,7 +11,7 @@ import (
 
 	"cdr.dev/wsep"
 	"github.com/spf13/pflag"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 	"nhooyr.io/websocket"
 
 	"go.coder.com/cli"
@@ -83,7 +83,7 @@ func do(fl *pflag.FlagSet, tty bool) {
 		signal.Notify(ch, syscall.SIGWINCH)
 		go func() {
 			for range ch {
-				width, height, err := terminal.GetSize(int(os.Stdin.Fd()))
+				width, height, err := term.GetSize(int(os.Stdin.Fd()))
 				if err != nil {
 					continue
 				}
@@ -92,11 +92,11 @@ func do(fl *pflag.FlagSet, tty bool) {
 		}()
 		ch <- syscall.SIGWINCH
 
-		oldState, err := terminal.MakeRaw(int(os.Stdin.Fd()))
+		oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 		if err != nil {
 			flog.Fatal("failed to make terminal raw for tty: %w", err)
 		}
-		defer terminal.Restore(int(os.Stdin.Fd()), oldState)
+		defer term.Restore(int(os.Stdin.Fd()), oldState)
 	}
 
 	go io.Copy(os.Stdout, process.Stdout())

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/spf13/pflag v1.0.5
 	go.coder.com/cli v0.4.0
 	go.coder.com/flog v0.0.0-20190906214207-47dd47ea0512
-	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	nhooyr.io/websocket v1.8.6
 )

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,10 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
The godoc for golang.org/x/crypto/ssh/terminal indicates that the
package is deprecated, moved to golang.org/x/term.

This PR changes the import from `golang.org/x/crypto/ssh/terminal` to `golang.org/x/term` and also usages from `terminal` to `term`. I'm currently on Windows, so have not tested this change, though it seems pretty straightforward to me. I also ran `go mod tidy` to update go.mod/go.sum.